### PR TITLE
Rename the libasound library after installation

### DIFF
--- a/plugins/music_service/volspotconnect/install.sh
+++ b/plugins/music_service/volspotconnect/install.sh
@@ -36,6 +36,13 @@ then
 			sudo tar -xf Volspotconnect.tar.xz -C /
 			rm Volspotconnect.tar.xz*
 
+			# Fix problems with the new ALSA (lib) update as of version 2.157
+			VERSION=$(cat /etc/os-release | grep VOLUMIO_VERSION | cut -d'"' -f 2)
+			BUILD=$(echo $VERSION | cut -d'.' -f 2)
+			if [ $(( $BUILD )) -gt 156 ] && [ "$cpu" = "armv7l" ];
+			then
+				mv /data/plugins/music_service/volspotconnect/spotify-connect-web/libasound.so.2 /data/plugins/music_service/volspotconnect/spotify-connect-web/libasound.so.2.dontuse
+			fi
 		else
 			echo "Failed to download. Stopping installation now"
 			exit -1


### PR DESCRIPTION
I have not tested all functionality just yet, but it should install and work on armv7l. The lastest updates in volumio rendered the plugin useless, because of incompatibility between ALSA and the included lib. I have not found anything that doesn't work, but please test it too.