### PR TITLE
[Volspotconnect2] Add software volume control methods for `None` mixer

### DIFF
--- a/plugins/music_service/volspotconnect2/UIConfig.json
+++ b/plugins/music_service/volspotconnect2/UIConfig.json
@@ -21,7 +21,8 @@
         "shareddevice",
         "username",
         "password",
-        "debug"
+        "debug",
+        "volume_ctrl"
       ]
     },
     "content": [{
@@ -107,13 +108,35 @@
         }
       },
       {
+        "id": "volume_ctrl",
+        "element": "select",
+        "doc": "TRANSLATE.VOLSPOTCONNECT.DESCPVOLUMECTRL",
+        "label": "TRANSLATE.VOLSPOTCONNECT.VOLUMECTRL",
+        "value": {
+          "value": "fixed",
+          "label": "TRANSLATE.VOLSPOTCONNECT.VOLUMECTRL_FIXED"
+        },
+        "options": [{
+            "value": "linear",
+            "label": "TRANSLATE.VOLSPOTCONNECT.VOLUMECTRL_LINEAR"
+          },
+          {
+            "value": "log",
+            "label": "TRANSLATE.VOLSPOTCONNECT.VOLUMECTRL_LOG"
+          },
+          {
+            "value": "fixed",
+            "label": "TRANSLATE.VOLSPOTCONNECT.VOLUMECTRL_FIXED"
+          }
+        ]
+      },
+      {
         "id": "debug",
         "element": "switch",
         "doc": "TRANSLATE.VOLSPOTCONNECT.DESCDEBUG",
         "label": "TRANSLATE.VOLSPOTCONNECT.DEBUG",
         "value": false
       }
-
     ]
   }]
 }

--- a/plugins/music_service/volspotconnect2/config.json
+++ b/plugins/music_service/volspotconnect2/config.json
@@ -26,5 +26,9 @@
   "debug": {
     "type": "boolean",
     "value": false
+  },
+  "volume_ctrl": {
+    "type": "string",
+    "value": "fixed"
   }
 }

--- a/plugins/music_service/volspotconnect2/i18n/strings_en.json
+++ b/plugins/music_service/volspotconnect2/i18n/strings_en.json
@@ -12,6 +12,11 @@
     "VOLNORM": "Normalisation volume",
     "DESCVOLNORM": "Set the same volume level for all songs",
     "DEBUG": "Debug mode",
-    "DESCDEBUG": "Enable verbose logs"
+    "DESCDEBUG": "Enable verbose logs",
+    "VOLUMECTRL": "Internal Volume Control",
+    "VOLUMECTRL_LINEAR": "Linear",
+    "VOLUMECTRL_LOG": "Logarithmic",
+    "VOLUMECTRL_FIXED": "Fixed",
+    "DESCPVOLUMECTRL": "Volume control (software) method"
   }
 }

--- a/plugins/music_service/volspotconnect2/i18n/strings_fr.json
+++ b/plugins/music_service/volspotconnect2/i18n/strings_fr.json
@@ -11,6 +11,11 @@
     "DESCINITVOL": "Volume par défaut pour Spotify",
     "VOLNORM": "Normalisation du volume",
     "DESCVOLNORM": "Règle le même volume pour tous les morceaux",
-    "DESCDEBUG": "Activation des logs de deboggage"
+    "DESCDEBUG": "Activation des logs de deboggage",
+    "VOLUMECTRL": "Internal Volume Control",
+    "VOLUMECTRL_LINEAR": "Linéaire",
+    "VOLUMECTRL_LOG": "Logarithmique",
+    "VOLUMECTRL_FIXED": "Fixed",
+    "DESCPVOLUMECTRL": "Method of (software) volume control"
   }
 }

--- a/plugins/music_service/volspotconnect2/i18n/strings_nl.json
+++ b/plugins/music_service/volspotconnect2/i18n/strings_nl.json
@@ -12,6 +12,11 @@
     "VOLNORM": "Volume normaliseren",
     "DESCVOLNORM": "Stel hetzelfde volume in voor alle nummers",
     "DEBUG": "Debugmodus",
-    "DESCDEBUG": "debuggen logs activeren"
+    "DESCDEBUG": "debuggen logs activeren",
+    "VOLUMECTRL": "Volumeregeling methode",
+    "VOLUMECTRL_LINEAR": "Lineaire",
+    "VOLUMECTRL_LOG": "Logaritmisch",
+    "VOLUMECTRL_FIXED": "Vast",
+    "DESCPVOLUMECTRL": "Methode voor de (software) volumeregeling"
   }
 }

--- a/plugins/music_service/volspotconnect2/package-lock.json
+++ b/plugins/music_service/volspotconnect2/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "volspotconnect2",
-	"version": "0.7.8",
+	"version": "0.9.6",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/plugins/music_service/volspotconnect2/package.json
+++ b/plugins/music_service/volspotconnect2/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "volspotconnect2",
-	"version": "0.9.5",
+	"version": "0.9.6",
 	"description": "Plugin for Spotify connect in Volumio2. Requires a Premium account or Family account",
 	"main": "index.js",
 	"scripts": {
@@ -10,7 +10,7 @@
 	"author": "Balbuze & Ashthespy",
 	"license": "GPL 3.0",
 	"vollibrespot": {
-		"version": "0.1.6"
+		"version": "0.1.7"
 	},
 	"volumio_info": {
 		"prettyName": "Volumio Spotify Connect2",


### PR DESCRIPTION
Can be linear, logarithmic, or fixed.
Needs vls >=0.1.7 (~that I have not yet released) - test with [vollibrespot.zip](https://github.com/ashthespy/Vollibrespot/files/3370580/vollibrespot.zip)~

If you let me know what the correct translations are for the `strings_fr`, would be happy to add them.

EDIT: 
@balbuze have released vls 0.1.7. Notable [changes](https://github.com/ashthespy/Vollibrespot/blob/master/CHANGELOG.md#017---2019-07-30):
* Refine dropped session handling
* Add a flag (`LIBRESPOT_RATE_RESAMPLE`) to allow resampling with ALSA
* Refactor Volume control, allow for a fixed volume option

Fixes #239, fixes #237, and closes https://github.com/volumio/Volumio2/issues/1771