### PR TITLE
Sync to ashthespy/Volumio-SpotifyConnect

### DIFF
--- a/plugins/music_service/volspotconnect2/index.js
+++ b/plugins/music_service/volspotconnect2/index.js
@@ -26,22 +26,19 @@ var seekTimer;
 module.exports = ControllerVolspotconnect;
 
 function ControllerVolspotconnect (context) {
-  var self = this;
   // Save a reference to the parent commandRouter
-  self.context = context;
-  self.commandRouter = self.context.coreCommand;
+  this.context = context;
+  this.commandRouter = this.context.coreCommand;
 
   // Volatile for metadata
-  self.unsetVol = function () {
-    var self = this;
+  this.unsetVol = () => {
     logger.info('unSetVolatile called');
-
-    return self.spotConnUnsetVolatile();
+    return this.spotConnUnsetVolatile();
   };
 
   // SpotifyWebApi
-  self.spotifyApi = new SpotifyWebApi();
-  self.device = undefined;
+  this.spotifyApi = new SpotifyWebApi();
+  this.device = undefined;
 }
 
 ControllerVolspotconnect.prototype.onVolumioStart = function () {
@@ -82,15 +79,16 @@ ControllerVolspotconnect.prototype.VolspotconnectServiceCmds = async function (c
 
 // For metadata
 ControllerVolspotconnect.prototype.volspotconnectDaemonConnect = function (defer) {
-  var self = this;
-  self.servicename = 'volspotconnect2';
-  self.displayname = 'volspotconnect2';
-  self.accessToken = '';
-  self.active = false;
-  self.DeviceActive = false;
-  self.SinkActive = false;
-  self.VLSStatus = '';
-  self.state = {
+  this.servicename = 'volspotconnect2';
+  this.displayname = 'volspotconnect2';
+  this.accessToken = '';
+  this.active = false;
+  this.isStopping = false;
+  this.DeviceActive = false;
+  this.SinkActive = false;
+  this.VLSStatus = '';
+  this.SPDevice = undefined; // WebAPI Device
+  this.state = {
     status: 'stop',
     service: 'volspotconnect2',
     title: '',
@@ -104,34 +102,30 @@ ControllerVolspotconnect.prototype.volspotconnectDaemonConnect = function (defer
     duration: 0,
     samplerate: '44.1 KHz',
     bitdepth: '16 bit',
+    bitrate: '',
     channels: 2
   };
 
   const nHost = ''; // blank = localhost
   const nPort = 5030;
   logger.info('Starting metadata listener');
-  self.SpotConn = new SpotConnCtrl({
+  this.SpotConn = new SpotConnCtrl({
     address: nHost,
     port: nPort
   });
-
-  self.SpotConn.sendmsg(msgMap.get('HELLO'));
+  this.Events = this.SpotConn.Events;
+  this.SpotConn.sendmsg(msgMap.get('Hello'));
 
   // Register callbacks from the daemon
-  self.SpotConn.on('error', function (err) {
+  this.SpotConn.on('error', (err) => {
     logger.error('Error connecting to metadata daemon', err);
     throw Error('Unable to connect to Spotify metadata daemon: ', err);
   });
 
-  self.SpotConn.on('status', (state) => {
-    logger.evnt('Status update: ', state);
-    self.VLSStatus = state;
-  });
-
-  self.SpotConn.on('SessionActive', function (data) {
+  this.SpotConn.on(this.Events.DeviceActive, (data) => {
   // A Spotify Connect session has been initiated
-    logger.evnt('Connect Session is active!');
-    self.commandRouter.pushToastMessage('info', 'Spotify Connect', 'Session is active!');
+    logger.evnt('<DeviceActive> A connect session has begun');
+    this.commandRouter.pushToastMessage('info', 'Spotify Connect', 'Session is active!');
     // Do not stop Volumio playback, just notify
 
     // self.volumioStop().then(() => {
@@ -140,169 +134,194 @@ ControllerVolspotconnect.prototype.volspotconnectDaemonConnect = function (defer
     // });
   });
 
-  self.SpotConn.on('DeviceActive', function (data) {
+  this.SpotConn.on(this.Events.PlaybackActive, (data) => {
   // SpotConn is active playback device
   // This is different from SinkActive, it will be triggered at the beginning
-  // of a playback session (e.g. Playlist)
-    logger.evnt('Device is active!');
-    self.commandRouter.pushToastMessage('info', 'Spotify Connect', 'Connect is active');
-    self.volumioStop().then(() => {
-      self.DeviceActive = true;
-      // self.state.status = 'play';
-      self.ActiveState();
-      self.pushState();
+  // of a playback session (e.g. Playlist) while the track loads
+    logger.evnt('<PlaybackActive> Device palyback is active!');
+    this.commandRouter.pushToastMessage('info', 'Spotify Connect', 'Connect is active');
+    this.volumioStop().then(() => {
+      this.DeviceActive = true;
+      // this.state.status = 'play';
+      this.ActiveState();
+      this.pushState();
     });
   });
 
-  self.SpotConn.on('SinkActive', function (data) {
-    // Alsa sink is active
-    logger.evnt('Sink acquired');
-    self.SinkActive = true;
-    self.checkWebApi();
-    self.state.status = 'play';
-    if (!self.active) self.ActiveState();
-    self.pushState();
+  this.SpotConn.on(this.Events.SinkActive, (data) => {
+    // Sink is active when actual playback starts
+    logger.evnt('<SinkActive> Sink acquired');
+    this.SinkActive = true;
+    this.checkWebApi();
+    this.state.status = 'play';
+    if (!this.active) this.ActiveState();
+    this.pushState();
   });
 
-  self.SpotConn.on('DeviceInactive', async function (data) {
-    logger.evnt('Device is inactive');
+  this.SpotConn.on(this.Events.PlaybackInactive, (data) => {
+    logger.evnt('<PlaybackInactive> Device palyback is inactive');
     // Device has finished playing current queue or received a pause command
     //  overkill async, who are we waiting for?
-    if (self.VLSStatus === 'pause') {
+    if (this.VLSStatus === 'pause') {
       logger.warn('Device is paused');
+    } else if (!this.active) {
+      logger.warn('Device is not active. Cleaning up!');
+      this.DeactivateState();
     } else {
-      await self.DeactivateState();
+      logger.warn(`Device Session is_active: ${this.active}`);
     }
   });
 
-  self.SpotConn.on('SinkInactive', function (data) {
+  this.SpotConn.on(this.Events.SinkInactive, (data) => {
   // Alsa sink has been closed
-    logger.evnt('Sink released');
-    self.SinkActive = false;
+    logger.evnt('<SinkInactive> Sink released');
+    this.SinkActive = false;
     clearInterval(seekTimer);
     seekTimer = undefined;
-    self.state.status = 'pause';
-    self.commandRouter.servicePushState(self.state, self.servicename);
+    this.state.status = 'pause';
+    if (this.active && !this.isStopping) {
+      this.commandRouter.servicePushState(this.state, this.servicename);
+    } else {
+      logger.debug(`Not pushing Pause { active: ${this.active}, isStopping: ${this.isStopping}}`);
+    }
   });
 
-  self.SpotConn.on('SessionInactive', async function (data) {
-  // Connect session has been exited
-    await self.DeactivateState();
-    logger.evnt('Connect Session is done');
+  this.SpotConn.on(this.Events.DeviceInactive, (data) => {
+    // Connect session has been exited
+    logger.evnt('<DeviceInactive> Connect Session has ended');
+    this.DeactivateState();
   });
 
-  self.SpotConn.on('seek', function (position) {
-    self.state.seek = position;
-    self.pushState();
+  this.SpotConn.on(this.Events.Seek, (position) => {
+    logger.evnt(`<Seek> ${position}`);
+    this.state.seek = position;
+    this.pushState();
   });
 
-  self.SpotConn.on('metadata', function (meta) {
+  this.SpotConn.on(this.Events.Metadata, (meta) => {
+    logger.evnt(`<Metadata> ${meta.track_name}`);
     // Update metadata
     const albumartId = meta.albumartId[2] === undefined ? meta.albumartId[0] : meta.albumartId[2];
-    self.state.uri = `spotify:track:${meta.track_id}`;
-    self.state.title = meta.track_name;
-    self.state.artist = meta.artist_name.join(', ');
-    self.state.album = meta.album_name;
-    self.state.duration = Math.ceil(meta.duration_ms / 1000);
-    self.state.seek = meta.position_ms;
-    self.state.albumart = `https://i.scdn.co/image/${albumartId}`;
-    logger.evnt(`Pushing metadata Vollibrespot: ${self.active}`);
-    // This will not succeed if volspotconnect2 isn't the current active service
-    self.pushState();
+    this.state.uri = `spotify:track:${meta.track_id}`;
+    this.state.title = meta.track_name;
+    this.state.artist = meta.artist_name.join(', ');
+    this.state.album = meta.album_name;
+    this.state.duration = Math.ceil(meta.duration_ms / 1000);
+    this.state.seek = meta.position_ms;
+    this.state.albumart = `https://i.scdn.co/image/${albumartId}`;
+    if (!this.isStopping) {
+      logger.debug('Pushing metadata');
+      // This will not succeed if volspotconnect2 isn't the current active service
+      this.pushState();
+    } else {
+      logger.debug(`Not pushing metadata: { active: ${this.active}, isStopping: ${this.isStopping} }`);
+    }
   });
 
-  self.SpotConn.on('token', function (token) {
-  // Init WebAPI with token
-    logger.var(`Token: <${token.accessToken}>`);
-    self.accessToken = token.accessToken;
-    self.initWebApi();
+  this.SpotConn.on(this.Events.Token, (token) => {
+    // Init WebAPI with token
+    logger.evnt(`<Token> ${token.accessToken}`);
+    this.accessToken = token.accessToken;
+    this.initWebApi();
   });
 
-  self.SpotConn.on('volume', function (SPvolume) {
-  // Listen to volume changes
-    const vol = Math.round(SPvolume);
-    logger.evnt(`Volume: Sp:${SPvolume} Volumio: ${vol}`);
-    self.commandRouter.volumioupdatevolume({
+  this.SpotConn.on(this.Events.Volume, (spvol) => {
+    // Listen to volume changes
+    logger.evnt(`<Volume> ${spvol}`);
+    const vol = Math.round(spvol);
+    logger.evnt(`Volume: Spotify:${spvol} Volumio: ${vol}`);
+    this.commandRouter.volumioupdatevolume({
       vol: vol,
       mute: false
     });
   });
 
-  self.SpotConn.on('state', function (state) {
-    logger.debug(state);
-    self.state.status = state.status;
-    self.state.seek = state.position;
-    logger.evnt(`Vollibrespot::status <${state.status}>`);
-    self.pushState();
+  this.SpotConn.on(this.Events.Status, (status) => {
+    logger.evnt(`<State> ${status}`);
+    this.VLSStatus = status;
   });
 
-  self.SpotConn.on('unknown', function (unknown) {
-    // logger.info('Vollibrespot:: ', unknown);
+  this.SpotConn.on(this.Events.Pong, (type) => {
+    logger.evnt(`<Pong> ${type}`);
   });
+
+  this.SpotConn.on(this.Events.Unknown, (msg, err) => {
+    // logger.evnt('<Unknown>', msg, err);
+  });
+};
+
+ControllerVolspotconnect.prototype.checkActive = async function () {
+  const res = await this.spotifyApi.getMyDevices();
+  if (res.statusCode !== 200) {
+    logger.debug('getMyDevices: ');
+    logger.debug(res);
+    return false;
+  }
+  const activeDevice = res.body.devices.find((el) => el.is_active === true);
+  if (activeDevice !== undefined) {
+    // This will fail if someone sets a custom name in the template..
+    if (this.commandRouter.sharedVars.get('system.name') === activeDevice.name) {
+      this.SPDevice = activeDevice;
+      logger.info(`Setting VLS device_id: ${activeDevice.id}`);
+      this.deviceID = activeDevice.id;
+      return true;
+    } else {
+      this.SPDevice = undefined;
+      return false;
+    }
+  } else {
+    logger.warn('No active spotify devices found');
+    logger.debug('Devices: ', res.body);
+    return false;
+  }
 };
 
 ControllerVolspotconnect.prototype.initWebApi = function () {
-  var self = this;
-  self.spotifyApi.setAccessToken(self.accessToken);
-  self.spotifyApi.getMyDevices()
-    .then(function (res) {
-      if (res.statusCode !== 200) {
-        logger.debug('getMyDevices: ');
-        logger.debug(res);
-      }
-      const device = res.body.devices.find((el) => el.is_active === true);
-      if (device !== undefined) {
-        self.commandRouter.sharedVars.get('system.name') === device.name ? self.device = device : self.deviceID = undefined;
-      } else {
-        logger.warn('No active spotify devices found');
-        logger.debug('Devices: ', res.body);
-        self.DeactivateState();
-      }
-    });
+  this.spotifyApi.setAccessToken(this.accessToken);
+  if (!this.checkActive()) {
+    this.DeactivateState();
+  }
 };
 
 ControllerVolspotconnect.prototype.checkWebApi = function () {
-  var self = this;
-  if (!self.accessToken || self.accessToken.length === 0) {
+  if (!this.accessToken || this.accessToken.length === 0) {
     logger.warn('Invalid webAPI token, requesting a new one...');
-    self.SpotConn.sendmsg(msgMap.get('GET_TOKEN'));
+    this.SpotConn.sendmsg(msgMap.get('ReqToken'));
   }
 };
 
 // State updates
 ControllerVolspotconnect.prototype.ActiveState = function () {
-  var self = this;
-  self.active = true;
+  this.active = true;
   // Vollibrespot is currently Active (Session|device)!
   logger.info('Vollibrespot Active');
-  if (!self.iscurrService()) {
+  if (!this.iscurrService()) {
     logger.info('Setting Volatile state to Volspotconnect2');
-    self.context.coreCommand.stateMachine.setConsumeUpdateService(undefined);
-    self.context.coreCommand.stateMachine.setVolatile({
-      service: self.servicename,
-      callback: self.unsetVol.bind(self)
+    this.context.coreCommand.stateMachine.setConsumeUpdateService(undefined);
+    this.context.coreCommand.stateMachine.setVolatile({
+      service: this.servicename,
+      callback: this.unsetVol
     });
   }
   // Push state with metadata
-  self.commandRouter.servicePushState(self.state, self.servicename);
+  this.commandRouter.servicePushState(this.state, this.servicename);
 };
 
 ControllerVolspotconnect.prototype.DeactivateState = async function () {
-  var self = this;
-  self.active = false;
+  this.active = false;
 
   // FIXME: use a differnt check
   // Giving up Volumio State
   return new Promise(resolve => {
     // Some silly race contions again. This should really be refactored!
     // logger.debug(`self.SinkActive  ${self.SinkActive} || self.DeviceActive ${self.DeviceActive}`);
-    if (self.SinkActive || self.DeviceActive) {
-      self.device === undefined ? logger.info('Relinquishing Volumio State')
-        : logger.warn(`Relinquishing Volumio state, Spotify session: ${self.device.is_active}`);
-      self.context.coreCommand.stateMachine.unSetVolatile();
-      self.context.coreCommand.stateMachine.resetVolumioState().then(() => {
-        self.context.coreCommand.volumioStop.bind(self.commandRouter);
-        self.DeviceActive = false;
+    if (this.SinkActive || this.DeviceActive) {
+      this.device === undefined ? logger.info('Relinquishing Volumio State')
+        : logger.warn(`Relinquishing Volumio state, Spotify session: ${this.device.is_active}`);
+      this.context.coreCommand.stateMachine.unSetVolatile();
+      this.context.coreCommand.stateMachine.resetVolumioState().then(() => {
+        this.context.coreCommand.volumioStop.bind(this.commandRouter);
+        this.DeviceActive = false;
       }
       );
     }
@@ -310,53 +329,48 @@ ControllerVolspotconnect.prototype.DeactivateState = async function () {
 };
 
 ControllerVolspotconnect.prototype.spotConnUnsetVolatile = function () {
-  var self = this;
-
   // FIXME: use a differnt check
-  self.device === undefined ? logger.info('Relinquishing Volumio State to another service')
-    : logger.warn(`Relinquishing Volumio state to another service, Spotify session: ${self.device.is_active}`);
+  this.device === undefined ? logger.info('Relinquishing Volumio State to another service')
+    : logger.warn(`Relinquishing Volumio state to another service, Spotify session: ${this.device.is_active}`);
 
-  // TODO: wait for confirmation from the SinkInactive event?
-  return self.stop();
+  return this.stop();
 };
 
 ControllerVolspotconnect.prototype.pushState = function () {
-  var self = this;
-  logger.state(`Pushing new state :: ${self.iscurrService()}`);
-  self.seekTimerAction();
+  logger.state(`Pushing new state :: ${this.iscurrService()}`);
+  this.seekTimerAction();
   // Push state
-  self.commandRouter.servicePushState(self.state, self.servicename);
+  this.commandRouter.servicePushState(this.state, this.servicename);
 };
 
 ControllerVolspotconnect.prototype.volumioStop = function () {
-  var self = this;
-  if (!self.iscurrService()) {
+  if (!this.iscurrService()) {
     logger.warn('Stopping currently active service');
-    return self.commandRouter.volumioStop();
+    return this.commandRouter.volumioStop();
+  } else {
+    logger.warn('Not requsting volumioStop on our own service');
   }
   return Promise.resolve(true);
 };
 
 ControllerVolspotconnect.prototype.iscurrService = function () {
   // Check what is the current Volumio service
-  var self = this;
-  const currentstate = self.commandRouter.volumioGetState();
+  const currentstate = this.commandRouter.volumioGetState();
   logger.info(`Currently active: ${currentstate.service}`);
-  if (currentstate !== undefined && currentstate.service !== undefined && currentstate.service !== self.servicename) {
+  if (currentstate !== undefined && currentstate.service !== undefined && currentstate.service !== this.servicename) {
     return false;
   }
   return true;
 };
 
 ControllerVolspotconnect.prototype.onStop = function () {
-  var self = this;
   try {
-    self.DeactivateState();
+    this.DeactivateState();
     logger.warn('Stopping Vollibrespot daemon');
-    self.VolspotconnectServiceCmds('stop');
+    this.VolspotconnectServiceCmds('stop');
     // Close the metadata pipe:
     logger.info('Closing metadata listener');
-    self.SpotConn.close();
+    this.SpotConn.close();
   } catch (e) {
     logger.error('Error stopping Vollibrespot daemon: ', e);
   }
@@ -378,13 +392,11 @@ ControllerVolspotconnect.prototype.init = async function () {
   } else {
     metrics.time('SpotifyConnect');
   }
-  var self = this;
   try {
-    // Do we need to create the file at each boot?
     // await creation?
-    self.createConfigFile();
-    self.volspotconnectDaemonConnect();
-    await self.VolspotconnectServiceCmds('start');
+    this.createConfigFile();
+    this.volspotconnectDaemonConnect();
+    await this.VolspotconnectServiceCmds('start');
 
     // Hook into Playback config
     // TODO: These are called multiple times, and there is no way to deregister them
@@ -414,14 +426,13 @@ ControllerVolspotconnect.prototype.onUninstall = function () {
 
 ControllerVolspotconnect.prototype.getUIConfig = function () {
   var defer = libQ.defer();
-  var self = this;
   const langCode = this.commandRouter.sharedVars.get('language_code');
-  self.commandRouter.i18nJson(path.join(__dirname, `/i18n/strings_${langCode}.json`),
+  this.commandRouter.i18nJson(path.join(__dirname, `/i18n/strings_${langCode}.json`),
     path.join(__dirname, '/i18n/strings_en.json'),
     path.join(__dirname, '/UIConfig.json'))
-    .then(function (uiconf) {
+    .then((uiconf) => {
       // Do we still need the initial volume setting?
-      const mixname = self.commandRouter.sharedVars.get('alsa.outputdevicemixer');
+      const mixname = this.commandRouter.sharedVars.get('alsa.outputdevicemixer');
       logger.debug(`config <${mixname}>: toggling initvol/volume_ctrl`);
       if ((mixname === '') || (mixname === 'None')) {
         uiconf.sections[0].content[0].hidden = false;
@@ -432,18 +443,18 @@ ControllerVolspotconnect.prototype.getUIConfig = function () {
       }
 
       // Asking for trouble, map index to id?
-      uiconf.sections[0].content[0].config.bars[0].value = self.config.get('initvol');
-      uiconf.sections[0].content[1].value = self.config.get('normalvolume');
-      uiconf.sections[0].content[2].value.value = self.config.get('bitrate');
-      uiconf.sections[0].content[2].value.label = self.config.get('bitrate').toString();
-      uiconf.sections[0].content[3].value = self.config.get('shareddevice');
-      uiconf.sections[0].content[4].value = self.config.get('username');
-      uiconf.sections[0].content[5].value = self.config.get('password');
-      uiconf.sections[0].content[6].value.label = self.config.get('volume_ctrl');
-      uiconf.sections[0].content[6].value.value = self.config.get('volume_ctrl');
-      uiconf.sections[0].content[7].value = self.config.get('gapless');
-      uiconf.sections[0].content[8].value = self.config.get('autoplay');
-      uiconf.sections[0].content[9].value = self.config.get('debug');
+      uiconf.sections[0].content[0].config.bars[0].value = this.config.get('initvol');
+      uiconf.sections[0].content[1].value = this.config.get('normalvolume');
+      uiconf.sections[0].content[2].value.value = this.config.get('bitrate');
+      uiconf.sections[0].content[2].value.label = this.config.get('bitrate').toString();
+      uiconf.sections[0].content[3].value = this.config.get('shareddevice');
+      uiconf.sections[0].content[4].value = this.config.get('username');
+      uiconf.sections[0].content[5].value = this.config.get('password');
+      uiconf.sections[0].content[6].value.label = this.config.get('volume_ctrl');
+      uiconf.sections[0].content[6].value.value = this.config.get('volume_ctrl');
+      uiconf.sections[0].content[7].value = this.config.get('gapless');
+      uiconf.sections[0].content[8].value = this.config.get('autoplay');
+      uiconf.sections[0].content[9].value = this.config.get('debug');
 
       defer.resolve(uiconf);
     })
@@ -465,55 +476,50 @@ ControllerVolspotconnect.prototype.getLabelForSelect = function (options, key) {
 
 /* eslint-disable no-unused-vars */
 ControllerVolspotconnect.prototype.setUIConfig = function (data) {
-  var self = this;
   // Perform your installation tasks here
 };
 
 ControllerVolspotconnect.prototype.getConf = function (varName) {
-  var self = this;
   // Perform your installation tasks here
 };
 
 ControllerVolspotconnect.prototype.setConf = function (varName, varValue) {
-  var self = this;
   // Perform your installation tasks here
 };
 /* eslint-enable no-unused-vars */
 
 ControllerVolspotconnect.prototype.getAdditionalConf = function (type, controller, data) {
-  var self = this;
-  return self.commandRouter.executeOnPlugin(type, controller, 'getConfigParam', data);
+  return this.commandRouter.executeOnPlugin(type, controller, 'getConfigParam', data);
 };
 
 // Public Methods ---------------------------------------------------------------------------------------
 
 ControllerVolspotconnect.prototype.createConfigFile = async function () {
-  var self = this;
   logger.info('Creating VLS config file');
   try {
     let template = readFile(path.join(__dirname, 'volspotify.tmpl'));
     // Authentication
-    const shared = (self.config.get('shareddevice'));
-    const username = (self.config.get('username'));
-    const password = (self.config.get('password'));
+    const shared = (this.config.get('shareddevice'));
+    const username = (this.config.get('username'));
+    const password = (this.config.get('password'));
     // Playback
-    const normalvolume = self.config.get('normalvolume');
+    const normalvolume = this.config.get('normalvolume');
     let initvol = '0';
-    const volumestart = self.commandRouter.executeOnPlugin('audio_interface', 'alsa_controller', 'getConfigParam', 'volumestart');
+    const volumestart = this.commandRouter.executeOnPlugin('audio_interface', 'alsa_controller', 'getConfigParam', 'volumestart');
     if (volumestart !== 'disabled') {
       initvol = volumestart;
     } else {
       // This will fail now - as stateMachine might not (yet) be up and running
       // TODO: Make these calls awaitable.
-      // const state = self.commandRouter.volumioGetState();
+      // const state = this.commandRouter.volumioGetState();
       // if (state) {
       //   initvol = (`${state.volume}`);
       // }
     }
-    const devicename = self.commandRouter.sharedVars.get('system.name');
-    const outdev = self.commandRouter.sharedVars.get('alsa.outputdevice');
-    const volcuve = self.commandRouter.executeOnPlugin('audio_interface', 'alsa_controller', 'getConfigParam', 'volumecurvemode');
-    let mixname = self.commandRouter.sharedVars.get('alsa.outputdevicemixer');
+    const devicename = this.commandRouter.sharedVars.get('system.name');
+    const outdev = this.commandRouter.sharedVars.get('alsa.outputdevice');
+    const volcuve = this.commandRouter.executeOnPlugin('audio_interface', 'alsa_controller', 'getConfigParam', 'volumecurvemode');
+    let mixname = this.commandRouter.sharedVars.get('alsa.outputdevicemixer');
     /* eslint-disable one-var */
     // Default values will be parsed as neccesary by the backend for these
     let idxcard = '',
@@ -521,16 +527,17 @@ ControllerVolspotconnect.prototype.createConfigFile = async function () {
       mixer = '',
       mixdev = '',
       mixeropts = '',
-      initvolstr = '';
+      initvolstr = '',
+      mixidx = 0;
     /* eslint-enable one-var */
     let mixlin = false;
     if ((mixname === '') || (mixname === 'None')) {
       logger.debug('<> or <None> Mixer found, using softvol');
       // No mixer - default to (linear) Spotify volume
       mixer = 'softvol';
-      mixeropts = self.config.get('volume_ctrl');
+      mixeropts = this.config.get('volume_ctrl');
       hwdev = `plughw:${outdev}`;
-      initvolstr = self.config.get('initvol');
+      initvolstr = this.config.get('initvol');
     } else {
       // Some mixer is defined, set inital volume to startup volume or current volume
       mixer = 'alsa';
@@ -541,12 +548,7 @@ ControllerVolspotconnect.prototype.createConfigFile = async function () {
       if (outdev === 'softvolume') {
         hwdev = outdev;
         mixlin = true;
-      } else {
-        hwdev = `plughw:${outdev}`;
-      }
-
-      if (outdev === 'softvolume') {
-        idxcard = self.getAdditionalConf('audio_interface', 'alsa_controller', 'softvolumenumber');
+        idxcard = this.getAdditionalConf('audio_interface', 'alsa_controller', 'softvolumenumber');
       } else if (outdev === 'Loopback') {
         const vconfig = fs.readFileSync('/tmp/vconfig.json', 'utf8', function (err, data) {
           if (err) {
@@ -556,14 +558,20 @@ ControllerVolspotconnect.prototype.createConfigFile = async function () {
         const vconfigJSON = JSON.parse(vconfig);
         idxcard = vconfigJSON.outputdevice.value;
         mixname = vconfigJSON.mixer.value;
-      } else {
-        idxcard = outdev;
+      } else { // We have an actual Hardware mixer
+        hwdev = `plughw:${outdev}`;
+        // outputdevice = card,device..
+        // ¯\_(ツ)_/¯
+        idxcard = outdev.split(',')[0];
+        // Similar storey with mixer,index
+        [mixname, mixidx] = mixname.split(',');
+        mixidx = mixidx || 0;
       }
 
       mixdev = `hw:${idxcard}`;
       mixeropts = 'linear';
     }
-    if (self.config.get('debug')) {
+    if (this.config.get('debug')) {
       // TODO:
       logger.debug('Unimplemented debug mode!!');
     }
@@ -578,12 +586,13 @@ ControllerVolspotconnect.prototype.createConfigFile = async function () {
       .replace('${mixer}', mixer)
       .replace('${mixname}', mixname)
       .replace('${mixdev}', mixdev)
+      .replace('${mixidx}', mixidx)
       .replace('${mixlin}', mixlin)
       .replace('${mixeropts}', mixeropts)
       .replace('${initvol}', initvolstr)
-      .replace('${autoplay}', self.config.get('autoplay'))
-      .replace('${gapless}', self.config.get('gapless'))
-      .replace('${bitrate}', self.config.get('bitrate'));
+      .replace('${autoplay}', this.config.get('autoplay'))
+      .replace('${gapless}', this.config.get('gapless'))
+      .replace('${bitrate}', this.config.get('bitrate'));
       /* eslint-enable no-template-curly-in-string */
 
     // Sanity check
@@ -592,35 +601,33 @@ ControllerVolspotconnect.prototype.createConfigFile = async function () {
       // get some hints as to what when wrong
       const trouble = conf.match(/^.*\b(undefined)\b.*$/gm);
       logger.error('volspotify config error: ', trouble);
-      self.commandRouter.pushToastMessage('stickyerror', 'Spotify Connect', `Error reading config: ${trouble}`);
+      this.commandRouter.pushToastMessage('stickyerror', 'Spotify Connect', `Error reading config: ${trouble}`);
       throw Error('Undefined found found in conf');
     }
     return writeFile('/data/plugins/music_service/volspotconnect2/volspotify.toml', conf);
   } catch (e) {
     logger.error('Error creating SpotifyConnect Daemon config', e);
-    self.commandRouter.pushToastMessage('error', 'Spotify Connect', `SpotifyConnect config failed: ${e}`);
+    this.commandRouter.pushToastMessage('error', 'Spotify Connect', `SpotifyConnect config failed: ${e}`);
   }
 };
 
 ControllerVolspotconnect.prototype.saveVolspotconnectAccount = function (data) {
-  var self = this;
-
   // TODO: is this still requred?
   // Does UIConfig - onSave() actually resolve this promise?
   var defer = libQ.defer();
 
-  self.config.set('initvol', data.initvol);
-  self.config.set('bitrate', data.bitrate.value);
-  self.config.set('normalvolume', data.normalvolume);
-  self.config.set('shareddevice', data.shareddevice);
-  self.config.set('username', data.username);
-  self.config.set('password', data.password);
-  self.config.set('volume_ctrl', data.volume_ctrl.value);
-  self.config.set('gapless', data.gapless);
-  self.config.set('autoplay', data.autoplay);
-  self.config.set('debug', data.debug);
-
-  self.rebuildRestartDaemon()
+  this.config.set('initvol', data.initvol);
+  this.config.set('bitrate', data.bitrate.value);
+  this.config.set('normalvolume', data.normalvolume);
+  this.config.set('shareddevice', data.shareddevice);
+  this.config.set('username', data.username);
+  this.config.set('password', data.password);
+  this.config.set('volume_ctrl', data.volume_ctrl.value);
+  this.config.set('gapless', data.gapless);
+  this.config.set('autoplay', data.autoplay);
+  this.config.set('debug', data.debug);
+  this.state.bitrate = data.bitrate;
+  this.rebuildRestartDaemon()
     .then(() => defer.resolve({}))
     .catch((e) => defer.reject(new Error('saveVolspotconnectAccountError')));
 
@@ -628,80 +635,131 @@ ControllerVolspotconnect.prototype.saveVolspotconnectAccount = function (data) {
 };
 
 ControllerVolspotconnect.prototype.rebuildRestartDaemon = async function () {
-  var self = this;
   // Deactive state
-  self.DeactivateState();
+  this.DeactivateState();
   try {
-    await self.createConfigFile();
+    await this.createConfigFile();
     logger.info('Restarting Vollibrespot Daemon');
-    await self.VolspotconnectServiceCmds('restart');
-    self.commandRouter.pushToastMessage('success', 'Spotify Connect', 'Configuration has been successfully updated');
+    await this.VolspotconnectServiceCmds('restart');
+    this.commandRouter.pushToastMessage('success', 'Spotify Connect', 'Configuration has been successfully updated');
   } catch (e) {
-    self.commandRouter.pushToastMessage('error', 'Spotify Connect', `Unable to update config: ${e}`);
+    this.commandRouter.pushToastMessage('error', 'Spotify Connect', `Unable to update config: ${e}`);
   }
+};
+
+ControllerVolspotconnect.prototype.awawitSpocon = function (type) {
+  return new Promise((resolve, reject) => {
+    this.SpotConn.once(type, resolve);
+    // If it takes more than 3 seconds, something is wrong..
+    setTimeout(() => { return reject; }, 3 * 1000);
+  });
 };
 
 // Plugin methods for the Volumio state machine
 ControllerVolspotconnect.prototype.stop = function () {
-  var self = this;
+  const volStop = process.hrtime();
   logger.cmd('Received stop');
-  // TODO: await confirmation of this command
-  self.SpotConn.sendmsg(msgMap.get('STOP'));
+  this.isStopping = true;
+  this.SpotConn.sendmsg(msgMap.get('Pause'));
+  // Statemachine doesn't seem Promise aware..¯\_(ツ)_/¯
+  // return this.awawitSpocon(this.Events.PongPause).then(() => {
+  // TODO: Is this sufficient, or should we wait for SinkInactive event..
+  return this.awawitSpocon(this.Events.SinkInactive).then(() => {
+    this.active = false;
+    this.isStopping = false;
+    const end = process.hrtime(volStop);
+    logger.debug(`ResolvedStop in \u001b[31m ${end[0]}s ${(end[1] / 1000000).toFixed(2)}ms \u001b[39m`);
+  }).catch(error => {
+    logger.error(error);
+  });
 };
 
 ControllerVolspotconnect.prototype.pause = function () {
-  var self = this;
   logger.cmd('Received pause');
 
-  return self.spotifyApi.pause().catch(error => {
-    self.commandRouter.pushToastMessage('error', 'Spotify Connect API Error', error.message);
+  return this.spotifyApi.pause().catch(error => {
+    this.commandRouter.pushToastMessage('error', 'Spotify Connect API Error', error.message);
     logger.error(error);
   });
 };
 
 ControllerVolspotconnect.prototype.play = function () {
-  var self = this;
-  logger.cmd('Received play');
-  return self.spotifyApi.play().catch(error => {
-    self.commandRouter.pushToastMessage('error', 'Spotify Connect API Error', error.message);
-    logger.error(error);
-  });
+  logger.cmd(`Received play: <${this.active}>`);
+  if (this.active) {
+    return this.spotifyApi.play().then(e => {
+      if (this.state.status !== 'play') {
+        this.state.staus = 'play';
+        this.pushState();
+      }
+    }).catch(error => {
+      this.commandRouter.pushToastMessage('error', 'Spotify Connect API Error', error.message);
+      logger.error(error);
+      this.checkActive();
+    });
+  } else {
+    logger.debug('Playing on:', this.deviceID);
+    return this.spotifyApi.transferMyPlayback({ deviceIds: [this.deviceID], play: true }).catch(error => {
+      this.commandRouter.pushToastMessage('error', 'Spotify Connect API Error', error.message);
+      logger.error(error);
+    });
+  }
 };
 
 ControllerVolspotconnect.prototype.next = function () {
-  var self = this;
   logger.cmd('Received next');
-  return self.spotifyApi.skipToNext().catch(error => {
-    self.commandRouter.pushToastMessage('error', 'Spotify Connect API Error', error.message);
+  return this.spotifyApi.skipToNext().catch(error => {
+    this.commandRouter.pushToastMessage('error', 'Spotify Connect API Error', error.message);
     logger.error(error);
   });
 };
 
 ControllerVolspotconnect.prototype.previous = function () {
-  var self = this;
   logger.cmd('Received previous');
-  return self.spotifyApi.skipToPrevious().catch(error => {
-    self.commandRouter.pushToastMessage('error', 'Spotify Connect API Error', error.message);
+  return this.spotifyApi.skipToPrevious().catch(error => {
+    this.commandRouter.pushToastMessage('error', 'Spotify Connect API Error', error.message);
     logger.error(error);
   });
 };
 
 ControllerVolspotconnect.prototype.seek = function (position) {
-  var self = this;
   logger.cmd(`Received seek to: ${position}`);
-  return self.spotifyApi.seek(position).catch(error => {
-    self.commandRouter.pushToastMessage('error', 'Spotify Connect API Error', error.message);
+  return this.spotifyApi.seek(position).catch(error => {
+    this.commandRouter.pushToastMessage('error', 'Spotify Connect API Error', error.message);
+    logger.error(error);
+  });
+};
+
+ControllerVolspotconnect.prototype.random = function (value) {
+  logger.cmd(`Received Random: ${value}`);
+  return this.spotifyApi.setShuffle({ state: value }).then(() => {
+    this.state.random = value;
+    this.pushState();
+  }).catch(error => {
+    this.commandRouter.pushToastMessage('error', 'Spotify Connect API Error', error.message);
+    logger.error(error);
+  });
+};
+
+ControllerVolspotconnect.prototype.repeat = function (value, repeatSingle) {
+  let state = value ? 'context' : 'off';
+  state = repeatSingle ? 'track' : state;
+  logger.cmd(`Received Repeat: ${value}-${repeatSingle} => ${state}`);
+  // track, context or off.
+  return this.spotifyApi.setRepeat({ state: state }).then(() => {
+    this.state.repeat = value;
+    this.state.repeatSingle = repeatSingle;
+    this.pushState();
+  }).catch(error => {
+    this.commandRouter.pushToastMessage('error', 'Spotify Connect API Error', error.message);
     logger.error(error);
   });
 };
 
 ControllerVolspotconnect.prototype.seekTimerAction = function () {
-  var self = this;
-
-  if (self.state.status === 'play') {
+  if (this.state.status === 'play') {
     if (seekTimer === undefined) {
       seekTimer = setInterval(() => {
-        self.state.seek = self.state.seek + 1000;
+        this.state.seek = this.state.seek + 1000;
       }, 1000);
     }
   } else {

--- a/plugins/music_service/volspotconnect2/package.json
+++ b/plugins/music_service/volspotconnect2/package.json
@@ -10,7 +10,7 @@
 	"author": "Balbuze & Ashthespy",
 	"license": "GPL 3.0",
   "vollibrespot": {
-    "version": "0.2.0"
+    "version": "0.2.1"
   },
 	"volumio_info": {
 		"prettyName": "Volumio Spotify Connect2",
@@ -26,6 +26,6 @@
     "v-conf": "^1.4.2"
   },
 	"devDependencies": {
-		"semistandard": "12.0.1"
+		"semistandard": "14.2.0"
 	}
 }

--- a/plugins/music_service/volspotconnect2/volspotify.tmpl
+++ b/plugins/music_service/volspotconnect2/volspotify.tmpl
@@ -20,7 +20,7 @@ initial-volume = ${initvol}
 mixer = '${mixer}' # softvolume or alsa
 mixer-name = '${mixname}'
 mixer-card = '${mixdev}'
-# mixer-index = 0
+mixer-index = ${mixidx}
 # Disable alsa's mapped volume scale (cubic). Default false
 mixer-linear-volume = ${mixlin}
 backend = 'alsa'


### PR DESCRIPTION
Updated Vls to [[0.2.1] - 2020-05-15](https://github.com/ashthespy/Vollibrespot/blob/master/CHANGELOG.md#021---2020-05-15) and made quite a few improvements to the core plugin logic:
- Add in some device/card mixer/index parsing logic
- Tweak stopping volatile service
- Add (initial) support for shuffle and repeat
- Don't await deactivation, clean up last `self`s
- Refactor `self` to `this`
- Refactor event notification
- Add bitrate info to sate
- Allow WebUI to resume playback if device is available 

Basically this a dump of [ashthespy/Volumio-SpotifyConnect](https://github.com/ashthespy/Volumio-SpotifyConnect/commits/next)
