### PR TITLE
Bump Vollibrespot to v0.2.2

### DIFF
--- a/plugins/music_service/volspotconnect2/package.json
+++ b/plugins/music_service/volspotconnect2/package.json
@@ -10,7 +10,7 @@
 	"author": "Balbuze & Ashthespy",
 	"license": "GPL 3.0",
 	"vollibrespot": {
-		"version": "0.2.1"
+		"version": "0.2.2"
 	},
 	"volumio_info": {
 		"prettyName": "Volumio Spotify Connect2",


### PR DESCRIPTION
Some small fixes [v0.2.2 - 2020-10-07](https://github.com/ashthespy/Vollibrespot/blob/master/CHANGELOG.md#022---2020-10-07), shouldn't break anything ;-)